### PR TITLE
Add Darkmoon (GPL-3.0 autonomous AI pentest platform)

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,7 @@ Everything is split into **🔴 Offensive (Red Team)**, **🔵 Defensive (Blue T
 | [MITRE ATT&CK](https://attack.mitre.org/) | Global knowledge base of adversary tactics & techniques. |
 | [OWASP](https://owasp.org/) | Foundation for web/app security standards & projects. |
 | [PortSwigger Web Security Academy](https://portswigger.net/web-security/all-topics) | Free, hands-on web-security training. |
+| [Darkmoon](https://github.com/ASCIT31/Dark-Moon) | Open source (GPL-3.0) autonomous AI pentest platform for web, API, Active Directory and Kubernetes, running as an MCP host with a local privacy gateway. |
 | [ProjectDiscovery](https://github.com/projectdiscovery) | Home of subfinder/httpx/nuclei & the recon ecosystem. |
 | [Awesome-Cybersecurity-Handbooks](https://github.com/0xsyr0/Awesome-Cybersecurity-Handbooks) | Huge handbook of techniques, tools & notes. |
 | [reverse-skill](https://github.com/zhaoxuya520/reverse-skill) | Reverse-engineering & pentest skill notes. |


### PR DESCRIPTION
Hi, and thanks for maintaining this list.

We would like to add Darkmoon, a GPL-3.0 autonomous AI penetration testing platform. It covers web, API, Active Directory and Kubernetes, and it runs as an MCP host orchestrating offensive tools. A local privacy gateway keeps target data (real IPs, hostnames, credentials) away from the LLM. Repo: https://github.com/ASCIT31/Dark-Moon

Full disclosure: this is our project. Happy to adjust the wording or placement, or to close this if it is not a fit.